### PR TITLE
Add PHP8.0 version support

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -114,9 +114,9 @@ jobs:
           restore-keys: "composer-cache"
       - name: "Install lowest dependencies"
         if: ${{ matrix.dependencies == 'lowest' }}
-        run: "composer update ${{ env.COMPOSER_FLAGS }} --prefer-lowest  --ignore-platform-reqs"
+        run: "composer update ${{ env.COMPOSER_FLAGS }} --prefer-lowest"
       - name: "Install highest dependencies"
         if: ${{ matrix.dependencies == 'highest' }}
-        run: "composer install ${{ env.COMPOSER_FLAGS }} --ignore-platform-reqs"
+        run: "composer install ${{ env.COMPOSER_FLAGS }}"
       - name: "Run PHPUnit"
         run: "vendor/bin/phpunit --testdox --coverage-text"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": "^7.4"
+        "php": "^7.4|^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",


### PR DESCRIPTION
# Changed log

- Adding the `php-8.0` version for requiring this PHP package.
- Removing the `--ignore-platform-reqs` option because it doesn't need to ignore platform requirements when running `composer install` command.