### PR TITLE
strtoupper solves problem when the string lowercase k

### DIFF
--- a/src/Rut.php
+++ b/src/Rut.php
@@ -46,6 +46,8 @@ final readonly class Rut
      */
     public static function parse(string $rut): Rut
     {
+        // String to upper to avoid problem with k instead of K
+        $rut = strtoupper($rut);
         // Remove space, dots and hyphens
         $rut = \str_replace([' ', '.', '-'], '', $rut);
 


### PR DESCRIPTION
Al recibir rut con k minuscula, daba error de validacion del rut, agregando un strtoupper antes de parsear el rut corrige esto y ahorra validar que la K sea mayuscula.